### PR TITLE
silence command-in-sbin-has-manpage-in-incorrect-section

### DIFF
--- a/debian/btrbk.lintian-overrides
+++ b/debian/btrbk.lintian-overrides
@@ -1,2 +1,4 @@
 # Python script is only used for (optional) KDF encryption of raw targets.
 btrbk binary: python-script-but-no-python-dep usr/share/btrbk/scripts/kdf_pbkdf2.py
+# btrbk is in /usr/sbin for historical reasons, migration to /usr/bin is planned.
+btrbk binary: command-in-sbin-has-manpage-in-incorrect-section


### PR DESCRIPTION
We have to ignore "command-in-sbin-has-manpage-in-incorrect-section" for now. I plan to move btrbk to /usr/bin anyway, the only reason why it resides in /usr/sbin is historical "well, btrfs-progs are in /sbin too" considerations. This has many implications and people will probably hate me for it.