### PR TITLE
Fix day-of-week for changelog entry 0.16-1.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+btrbk (0.29.0-2) UNRELEASED; urgency=medium
+
+  * Fix day-of-week for changelog entry 0.16-1.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 10 Dec 2019 03:30:31 +0000
+
 btrbk (0.29.0-1) experimental; urgency=low
 
   * New upstream release.
@@ -325,7 +331,7 @@ btrbk (0.16-1) UNRELEASED; urgency=high
   * New upstream release.
   * Bugfix: correctly check retention policy for missing backups
 
- -- Axel Burri <axel@tty0.ch>  Wed, 02 Apr 2015 17:27:22 +0100
+ -- Axel Burri <axel@tty0.ch>  Thu, 02 Apr 2015 17:27:22 +0100
 
 btrbk (0.15-1) UNRELEASED; urgency=low
 


### PR DESCRIPTION
Fix day-of-week for changelog entry 0.16-1.

This merge proposal was created automatically by the Janitor bot
(https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/btrbk/07f20cb1-7ed3-40d6-9314-9052a1d66d49.
