### PR TITLE
Refer to specific version of license GPL-3+

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+btrbk (0.29.1-2) UNRELEASED; urgency=medium
+
+  * Refer to specific version of license GPL-3+.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 06 May 2020 17:56:20 +0000
+
 btrbk (0.29.1-1) experimental; urgency=medium
 
   * New upstream release.

--- a/debian/copyright
+++ b/debian/copyright
@@ -19,4 +19,4 @@ License: GPL-3+
  along with this program. If not, see <http://www.gnu.org/licenses/>
  .
  On Debian systems, the complete text of the GNU General
- Public License version 3 can be found in "/usr/share/common-licenses/GPL".
+ Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".


### PR DESCRIPTION
Refer to specific version of license GPL-3+. ([copyright-refers-to-symlink-license](https://lintian.debian.org/tags/copyright-refers-to-symlink-license.html), [copyright-refers-to-versionless-license-file](https://lintian.debian.org/tags/copyright-refers-to-versionless-license-file.html))

This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/btrbk/f72cb0d5-20b4-448a-904e-475a502a875e.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/f72cb0d5-20b4-448a-904e-475a502a875e/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/f72cb0d5-20b4-448a-904e-475a502a875e/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/f72cb0d5-20b4-448a-904e-475a502a875e/diffoscope)).
