### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Uploaders: Yaroslav Halchenko <debian@onerussian.com>
 Standards-Version: 4.6.1
 Build-Depends:
  debhelper (>= 12),
- asciidoctor (>= 1.5.7),
+ asciidoctor,
 Homepage: https://digint.ch/btrbk/
 Vcs-Git: https://github.com/digint/btrbk-packaging -b debian
 Vcs-Browser: https://github.com/digint/btrbk-packaging
@@ -14,7 +14,7 @@ Vcs-Browser: https://github.com/digint/btrbk-packaging
 
 Package: btrbk
 Architecture: all
-Depends: perl, btrfs-progs (>= 4.12), ${misc:Depends}
+Depends: perl, btrfs-progs, ${misc:Depends}
 Recommends: openssh-client, mbuffer
 Suggests:
  openssl,


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/btrbk/7aeea319-0909-4423-baaf-286b54e3d41d.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* Depends: perl, btrfs-progs [-(>= 4.12)-]


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/7aeea319-0909-4423-baaf-286b54e3d41d/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/7aeea319-0909-4423-baaf-286b54e3d41d/diffoscope)).
